### PR TITLE
update zlib to support ssp

### DIFF
--- a/package/libs/zlib/Makefile
+++ b/package/libs/zlib/Makefile
@@ -24,6 +24,7 @@ define Package/zlib
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Library implementing the deflate compression method
+  DEPENDS:=+SSP_SUPPORT:libssp
   URL:=http://www.zlib.net/
 endef
 


### PR DESCRIPTION
if SSP is turned on, it fails with missing dep on libssp, this fixes that build error
